### PR TITLE
Design implementation of branding and keyword search

### DIFF
--- a/NZSLDict.xcodeproj/project.pbxproj
+++ b/NZSLDict.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03617D8B1EE8DA2400E26B34 /* PaddedUISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03617D8A1EE8DA2400E26B34 /* PaddedUISearchBar.swift */; };
 		03B1C8981EE75B4F008A875C /* SignsDictionaryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B1C8971EE75B4F008A875C /* SignsDictionaryTest.swift */; };
 		374E59E0173260B9004C7D44 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374E59DF173260B9004C7D44 /* QuartzCore.framework */; };
 		37B3111515133261005F45FA /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37B3111415133261005F45FA /* MediaPlayer.framework */; };
@@ -84,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03617D8A1EE8DA2400E26B34 /* PaddedUISearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddedUISearchBar.swift; sourceTree = "<group>"; };
 		03B1C88C1EE75B0E008A875C /* NZSLDictTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NZSLDictTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03B1C8901EE75B0F008A875C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03B1C8971EE75B4F008A875C /* SignsDictionaryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignsDictionaryTest.swift; path = ../SignsDictionaryTest.swift; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 				4960AD7A1C28E2A5001037C4 /* imageutil.h */,
 				4960AD7B1C28E2A5001037C4 /* imageutil.m */,
 				499DFD8C1C3F483A00F45D0E /* NZSLDict-Bridging-Header.h */,
+				03617D8A1EE8DA2400E26B34 /* PaddedUISearchBar.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -549,6 +552,7 @@
 				4911054B1C4642F600A742BE /* ViewControllerDelegate.swift in Sources */,
 				49342F9E1C484B5800C355B2 /* Constants.swift in Sources */,
 				49342F981C481EB500C355B2 /* ViewControllerPad.swift in Sources */,
+				03617D8B1EE8DA2400E26B34 /* PaddedUISearchBar.swift in Sources */,
 				49342FAA1C4890CF00C355B2 /* SearchViewController.swift in Sources */,
 				49342F9A1C4821A800C355B2 /* AppDelegate.swift in Sources */,
 				4960AD8C1C28E2A5001037C4 /* imageutil.m in Sources */,
@@ -841,6 +845,7 @@
 				03B1C8951EE75B0F008A875C /* Distribution */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		37B3F2831512F946005F45FA /* Build configuration list for PBXProject "NZSLDict" */ = {
 			isa = XCConfigurationList;

--- a/NZSLDict/Classes/AppDelegate.swift
+++ b/NZSLDict/Classes/AppDelegate.swift
@@ -5,14 +5,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        var rootViewController: UIViewController!
+
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
 
         if UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone {
-            self.window!.rootViewController = ViewControllerPhone()
+            rootViewController = ViewControllerPhone()
         } else {
-            self.window!.rootViewController = ViewControllerPad()
+            rootViewController = ViewControllerPad()
         }
+        
+        let navigationController: UINavigationController = UINavigationController.init(rootViewController: rootViewController)
+        navigationController.navigationBar.barStyle = UIBarStyle.Black;
+        navigationController.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.whiteColor()]
+        navigationController.navigationBar.barTintColor = AppThemePrimaryColor;
+        navigationController.navigationBar.translucent = false
+        
+    
+        self.window!.rootViewController = navigationController
         self.window!.makeKeyAndVisible()
+        
+
         return true
     }
 

--- a/NZSLDict/Classes/Constants.swift
+++ b/NZSLDict/Classes/Constants.swift
@@ -3,3 +3,5 @@
 // TODO: there is probably a better way to handle these in swift
 
 let EntrySelectedName = "EntrySelected"
+let AppThemePrimaryColor = UIColor(red:0.16, green:0.50, blue:0.73, alpha:1.0)
+let AppThemeAccentColor = UIColor(red:0.96, green:0.47, blue:0.35, alpha:1.0)

--- a/NZSLDict/Classes/DiagramViewController.swift
+++ b/NZSLDict/Classes/DiagramViewController.swift
@@ -3,7 +3,6 @@ import UIKit
 class DiagramViewController: UIViewController, UISearchBarDelegate {
     var delegate: ViewControllerDelegate!
     var currentEntry: DictEntry!
-    var searchBar: UISearchBar!
     var diagramView: DiagramView!
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
@@ -23,12 +22,8 @@ class DiagramViewController: UIViewController, UISearchBarDelegate {
     override func loadView() {
         let view: UIView = UIView(frame: UIScreen.mainScreen().bounds)
         view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        let top_offset: CGFloat = 20
-        searchBar = UISearchBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 44))
-        searchBar.autoresizingMask = .FlexibleWidth
-        searchBar.delegate = self
-        view.addSubview(searchBar)
-        diagramView = DiagramView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, view.bounds.size.height - (top_offset + 44)))
+        
+        diagramView = DiagramView(frame: CGRectMake(0, 0, view.bounds.size.width, view.bounds.size.height))
         view.addSubview(diagramView)
         self.view = view
     }
@@ -38,6 +33,10 @@ class DiagramViewController: UIViewController, UISearchBarDelegate {
         if self.respondsToSelector("edgesForExtendedLayout") {
             self.edgesForExtendedLayout = .None
         }
+    }
+    
+    func selectSearchMode(sender: UISegmentedControl) {
+            self.tabBarController?.selectedIndex = 0
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -53,16 +52,6 @@ class DiagramViewController: UIViewController, UISearchBarDelegate {
     }
 
     func showCurrentEntry() {
-        searchBar.text = currentEntry.gloss
         diagramView.showEntry(currentEntry)
-    }
-
-    func positionForBar(bar: UIBarPositioning) -> UIBarPosition {
-        return .TopAttached
-    }
-
-    func searchBarShouldBeginEditing(searchBar: UISearchBar) -> Bool {
-        self.delegate.returnToSearchView()
-        return false
     }
 }

--- a/NZSLDict/Classes/PaddedUISearchBar.swift
+++ b/NZSLDict/Classes/PaddedUISearchBar.swift
@@ -1,0 +1,11 @@
+class PaddedUISearchBar: UISearchBar {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let pad: CGFloat = 16
+        for view: UIView in subviews {
+            if (view is UITextField) {
+                view.frame = CGRect(x: CGFloat(view.frame.origin.x + pad), y: CGFloat(view.frame.origin.y), width: CGFloat(view.frame.size.width - pad), height: CGFloat(view.frame.size.height))
+            }
+        }
+    }
+}

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -142,7 +142,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
     override func loadView() {
         self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
-        searchBar = UISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
+        searchBar = PaddedUISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
         searchBar.autoresizingMask = .FlexibleWidth
         searchBar.barTintColor = AppThemePrimaryColor
         searchBar.delegate = self
@@ -152,7 +152,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         modeSwitch.autoresizingMask = .FlexibleLeftMargin
         modeSwitch.frame = CGRectMake(view.bounds.size.width - modeSwitch.bounds.size.width - 4, 0 + 6, modeSwitch.bounds.size.width, 32)
         modeSwitch.selectedSegmentIndex = 0
-        modeSwitch.tintColor = AppThemeAccentColor
+        modeSwitch.tintColor = UIColor.whiteColor();
         modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), forControlEvents: .ValueChanged)
       
         self.view.addSubview(modeSwitch)

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -308,6 +308,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     }
 
     func selectSearchMode(sender: UISegmentedControl) {
+        self.tabBarController?.selectedIndex = 0
         switch sender.selectedSegmentIndex {
         case 0:
             searchBar.text = ""

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -122,11 +122,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-
         self.tabBarItem = UITabBarItem(tabBarSystemItem: .Search, tag: 0)
-
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "adjustForKeyboard:", name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "adjustForKeyboard:", name: UIKeyboardWillHideNotification, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -145,26 +141,22 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     // MARK View lifecycle
 
     override func loadView() {
-        let view: UIView = UIView(frame: UIScreen.mainScreen().bounds)
-        view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        view.backgroundColor = UIColor(white: 0.9, alpha: 1)
-
-        let top_offset: CGFloat = 20
-
-        searchBar = UISearchBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 44))
+        self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
+        searchBar = UISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
         searchBar.autoresizingMask = .FlexibleWidth
-        searchBar.placeholder = "Enter Word"
+        searchBar.barTintColor = AppThemePrimaryColor
         searchBar.delegate = self
-        view.addSubview(searchBar)
+        self.view.addSubview(searchBar)
 
         modeSwitch = UISegmentedControl(items: ["Abc", UIImage(named: "hands")!])
         modeSwitch.autoresizingMask = .FlexibleLeftMargin
-        modeSwitch.frame = CGRectMake(view.bounds.size.width - modeSwitch.bounds.size.width - 4, top_offset + 6, modeSwitch.bounds.size.width, 32)
+        modeSwitch.frame = CGRectMake(view.bounds.size.width - modeSwitch.bounds.size.width - 4, 0 + 6, modeSwitch.bounds.size.width, 32)
         modeSwitch.selectedSegmentIndex = 0
-        modeSwitch.addTarget(self, action: "selectSearchMode:", forControlEvents: .ValueChanged)
-
-        view.addSubview(modeSwitch)
-        searchTable = UITableView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, view.bounds.size.height - (top_offset + 44)))
+        modeSwitch.tintColor = AppThemeAccentColor
+        modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), forControlEvents: .ValueChanged)
+      
+        self.view.addSubview(modeSwitch)
+        searchTable = UITableView(frame: CGRectMake(0, 0 + 44, view.bounds.size.width, view.bounds.size.height - (0 + 44)))
         searchTable.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         searchTable.rowHeight = 50
         searchTable.dataSource = self
@@ -178,7 +170,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         wotdView = UIView(frame: searchTable.frame)
         wotdView.autoresizingMask = .FlexibleWidth
         wotdView.backgroundColor = UIColor.whiteColor()
-        view.addSubview(wotdView)
+        self.view.addSubview(wotdView)
         wotdLabel = UILabel(frame: CGRectMake(0, 0, wotdView.bounds.size.width, 20))
         wotdLabel.autoresizingMask = .FlexibleWidth
         wotdLabel.textAlignment = .Center
@@ -240,7 +232,6 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         locationSelector.dataSource = self
         locationSelector.delegate = self
         searchSelectorView.addSubview(locationSelector)
-        self.view = view
     }
 
     override func viewDidLoad() {
@@ -252,7 +243,37 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
         dict = SignsDictionary(file: "nzsl.dat")
         wordOfTheDay = dict.wordOfTheDay()
-
+        
+        tabBarController?.title = nil
+        let navbarTitleFirstSegment = UILabel()
+        let navbarTitleSecondSegment = UILabel()
+        navbarTitleFirstSegment.textColor = UIColor.whiteColor();
+        navbarTitleSecondSegment.textColor = UIColor.whiteColor();
+        
+        if navbarTitleFirstSegment.respondsToSelector("setAttributedText:") {
+            let navbarTitleFirstSegmentText = NSMutableAttributedString(string: "NZSL", attributes: [NSFontAttributeName: UIFont.boldSystemFontOfSize(22)])
+            let navbarTitleSecondSegmentText = NSMutableAttributedString(string: "dictionary", attributes: [NSFontAttributeName: UIFont.italicSystemFontOfSize(22)])
+        
+            navbarTitleFirstSegment.attributedText = navbarTitleFirstSegmentText
+            navbarTitleSecondSegment.attributedText = navbarTitleSecondSegmentText
+        }
+        else {
+            navbarTitleFirstSegment.text = "NZSL "
+            navbarTitleSecondSegment.text = "dictionary"
+        }
+        
+        navbarTitleFirstSegment.sizeToFit();
+        navbarTitleSecondSegment.sizeToFit();
+        
+        self.tabBarController?.navigationItem.setLeftBarButtonItems([
+            UIBarButtonItem.init(customView: navbarTitleFirstSegment),
+            UIBarButtonItem.init(customView: navbarTitleSecondSegment)
+        ], animated: false)
+        
+        
+        let navigationBarRightButtonItem = UIBarButtonItem.init(customView: modeSwitch);
+        self.tabBarController?.navigationItem.setRightBarButtonItem(navigationBarRightButtonItem, animated: false)
+        
         if wotdLabel.respondsToSelector("setAttributedText:") {
             // iOS 6 supports attributed text in labels
             let xas: NSMutableAttributedString = NSMutableAttributedString(string: "Word of the day: ")
@@ -272,59 +293,10 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         self.selectSearchMode(modeSwitch)
     }
 
-    func shrinkSearchBar() {
-        let x: UIView = searchBar.subviews[0]
-        let y: UIView = x.subviews[1]
-        y.frame = CGRectMake(y.frame.origin.x, y.frame.origin.y, x.frame.size.width - (y.frame.origin.x * 2 + 100), y.frame.size.height)
-    }
-
-    override func viewDidLayoutSubviews() {
-        self.shrinkSearchBar()
-    }
-
     override func viewDidAppear(animated: Bool) {
-        self.shrinkSearchBar()
         if modeSwitch.selectedSegmentIndex == 0 && searchBar.text!.characters.count == 0 {
             searchBar.becomeFirstResponder()
         }
-    }
-
-
-    // TODO: not sure this workaround required in ios7+ ???
-    func adjustForKeyboard(notification: NSNotification) {
-//        var v: NSValue = notification.userInfo![UIKeyboardFrameEndUserInfoKey as NSObject]
-//        var kr: CGRect = v.CGRectValue()
-//        // This workaround avoids a problem when launching on the iPad in non-portrait mode.
-//        // On launch, the convertRect: call does not properly take into account the rotation
-//        // from device coordinates to interface coordinates. We seem to be able to detect
-//        // this when the following is true:
-//        var interface_orientation: UIInterfaceOrientation = UIApplication.sharedApplication().statusBarOrientation
-//        var device_orientation: UIDeviceOrientation = UIDevice.currentDevice().orientation
-//        //NSLog(@"interface %d device %d", interface_orientation, device_orientation);
-//        var fudge_rotation: Bool = Int(device_orientation) != Int(interface_orientation)
-//
-//        if fudge_rotation {
-//            //NSLog(@"before fudge %g %g %g %g", kr.origin.x, kr.origin.y, kr.size.width, kr.size.height);
-//            var screen: CGRect = UIScreen.mainScreen().bounds
-//            switch interface_orientation {
-//            case .LandscapeLeft:
-//                kr = CGRectMake(screen.size.height - (kr.origin.y + kr.size.height), kr.origin.x, kr.size.height, kr.size.width)
-//            case .LandscapeRight:
-//                kr = CGRectMake(kr.origin.y, screen.size.width - (kr.origin.x + kr.size.width), kr.size.height, kr.size.width)
-//            case .PortraitUpsideDown:
-//                kr = CGRectMake(screen.size.width - (kr.origin.x + kr.size.width), screen.size.height - (kr.origin.y + kr.size.height), kr.size.width, kr.size.height)
-//            default:
-//                break
-//            }
-//
-//            //NSLog(@"  after %g %g %g %g", kr.origin.x, kr.origin.y, kr.size.width, kr.size.height);
-//        }
-//        else {
-//            //NSLog(@"  before convertRect %g %g %g %g", kr.origin.x, kr.origin.y, kr.size.width, kr.size.height);
-//            kr = self.view!.convertRect(kr, fromView: nil)
-//            //NSLog(@"  after %g %g %g %g", kr.origin.x, kr.origin.y, kr.size.width, kr.size.height);
-//        }
-//        subsequent_keyboard = true
     }
 
     func selectWotd(sender: UITapGestureRecognizer) {

--- a/NZSLDict/Classes/VideoViewController.swift
+++ b/NZSLDict/Classes/VideoViewController.swift
@@ -3,7 +3,6 @@ import MediaPlayer
 
 class VideoViewController: UIViewController, UISearchBarDelegate {
     var currentEntry: DictEntry!
-    var searchBar: UISearchBar!
     var detailView: DetailView!
     var videoBack: UIView!
     var activity: UIActivityIndicatorView!
@@ -28,17 +27,10 @@ class VideoViewController: UIViewController, UISearchBarDelegate {
         let view: UIView = UIView(frame: UIScreen.mainScreen().bounds)
         view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
 
-        let top_offset: CGFloat = 20
-
-        searchBar = UISearchBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 44))
-        searchBar.autoresizingMask = .FlexibleWidth
-        searchBar.delegate = self
-        view.addSubview(searchBar)
-
-        detailView = DetailView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, DetailView.height))
+        detailView = DetailView(frame: CGRectMake(0, 0, view.bounds.size.width, DetailView.height))
         detailView.autoresizingMask = .FlexibleWidth
         view.addSubview(detailView)
-        videoBack = UIView(frame: CGRectMake(0, top_offset + 44 + DetailView.height, view.bounds.size.width, view.bounds.size.height - (top_offset + 44 + DetailView.height)))
+        videoBack = UIView(frame: CGRectMake(0, DetailView.height, view.bounds.size.width, view.bounds.size.height - DetailView.height))
         videoBack.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         view.addSubview(videoBack)
 
@@ -63,7 +55,6 @@ class VideoViewController: UIViewController, UISearchBarDelegate {
     }
 
     func showCurrentEntry() {
-        searchBar.text = currentEntry.gloss
         detailView.showEntry(currentEntry)
         self.performSelector("startVideo", withObject: nil, afterDelay: 0)
     }
@@ -106,12 +97,4 @@ class VideoViewController: UIViewController, UISearchBarDelegate {
         }
     }
 
-    func positionForBar(bar: UIBarPositioning) -> UIBarPosition {
-        return .TopAttached
-    }
-
-    func searchBarShouldBeginEditing(searchBar: UISearchBar) -> Bool {
-        self.delegate.returnToSearchView()
-        return false
-    }
 }


### PR DESCRIPTION
This pull request compliments the last Android PR and begins to implement the branding and UI for the iOS app. This pull request is focussed around adding the top bar and keyword search. It's mostly done (enough to PR at least), but there are still some things that I'd like to care of that I'll enumerate here:

1. I'd like the search box to have a little more margin on the left and right - I've had a stab at this, but it's a fairly minor thing and I'm going to loop back and fix it up if I have time.
2. The segmented button in the top right corner is red as per designs - I had it red, but Nanz and Nani pretty much ruled it straight out - it's not quite right. I've made it white for now. I also think the hand image is grainier than it should be (maybe it's not using the high DPI image?)
3. I've not written tests for the search UI like I did for the Android - basically the same reason as the first point - I'm worried I'll accidentally sink a whole afternoon getting it going when it's not really that important as long as manual testing continues to be done. I'll loop back to it if I have time at the end (I think I will) - or do it on a Friday.

Screenshot time!

Here's the design:

<img width="360" alt="screen shot 2017-06-07 at 10 59 20 am" src="https://user-images.githubusercontent.com/292020/26908459-e12b85f8-4c4e-11e7-92d7-bfed74586c01.png">

And screenshots from the app:

![simulator screen shot 8 06 2017 1 26 39 pm](https://user-images.githubusercontent.com/292020/26908471-eb23e8d4-4c4e-11e7-93fc-e1938badbe80.png)

![simulator screen shot 8 06 2017 1 26 47 pm](https://user-images.githubusercontent.com/292020/26908474-eddeae24-4c4e-11e7-85c4-f3ee6114db56.png)

![simulator screen shot 8 06 2017 1 27 57 pm](https://user-images.githubusercontent.com/292020/26908478-f0328ba0-4c4e-11e7-88fb-fac27b72990f.png)


