### PR TITLE
Tab Refactor

### DIFF
--- a/NZSLDict/Classes/HistoryViewController.swift
+++ b/NZSLDict/Classes/HistoryViewController.swift
@@ -10,7 +10,7 @@ class HistoryViewController: UITableViewController {
 
     override init(style: UITableViewStyle) {
         super.init(style: style)
-        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.Recents, tag: 0)
+        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.MostRecent, tag: 0)
             
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "addEntry:", name: EntrySelectedName, object: nil)
     }

--- a/NZSLDict/Classes/HistoryViewController.swift
+++ b/NZSLDict/Classes/HistoryViewController.swift
@@ -10,7 +10,8 @@ class HistoryViewController: UITableViewController {
 
     override init(style: UITableViewStyle) {
         super.init(style: style)
-        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.History, tag: 0)
+        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.Recents, tag: 0)
+            
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "addEntry:", name: EntrySelectedName, object: nil)
     }
 

--- a/NZSLDict/Classes/ViewControllerPhone.swift
+++ b/NZSLDict/Classes/ViewControllerPhone.swift
@@ -24,9 +24,9 @@ class ViewControllerPhone: UITabBarController, ViewControllerDelegate, SearchVie
 
         self.viewControllers = [
             searchController,
-            diagramController,
-            videoController,
             historyController,
+            diagramController,
+            videoController
         ]
 
         searchController.delegate = self


### PR DESCRIPTION
Just a small change following Nanz's recommendations to:

1. Show 'Search' and 'History' before 'Image' and 'Video'
2. Rename 'History' to 'Recent'. This was trickier than I had thought, because the tab bar is using system tab bar elements. According to this [StackOverflow post](https://stackoverflow.com/questions/16210522/how-to-set-title-with-uitabbarsystemitem), the title cannot be changed without using private APIs - so I could pick between using 'Recents', 'Most Recent', or adding a custom icon. For now, I have chosen to use 'Recents'.

The new tab bar:

![simulator screen shot 12 06 2017 8 58 28 am](https://user-images.githubusercontent.com/292020/27014444-6163296e-4f4d-11e7-9386-24655811d572.png)
