### PR TITLE
Fixes so that the app does not crash on iPad 

### DIFF
--- a/NZSLDict/Classes/AppDelegate.swift
+++ b/NZSLDict/Classes/AppDelegate.swift
@@ -13,6 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             rootViewController = ViewControllerPhone()
         } else {
             rootViewController = ViewControllerPad()
+            self.window!.rootViewController = rootViewController
+            self.window!.makeKeyAndVisible();
+            return true
         }
         
         let navigationController: UINavigationController = UINavigationController.init(rootViewController: rootViewController)

--- a/NZSLDict/Classes/Constants.swift
+++ b/NZSLDict/Classes/Constants.swift
@@ -6,3 +6,4 @@ let EntrySelectedName = "EntrySelected"
 let AppThemePrimaryColor = UIColor(red:0.16, green:0.50, blue:0.73, alpha:1.0)
 let AppThemeAccentColor = UIColor(red:0.96, green:0.47, blue:0.35, alpha:1.0)
 let AppSecondaryTextColour = UIColor(red:0.62, green:0.62, blue:0.62, alpha:1.0)
+let AppThemePrimaryLightColor = UIColor(red:0.88, green:0.93, blue:0.97, alpha:1.0)

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -100,8 +100,8 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     }
 
     func playerPlaybackStateDidChange(notification: NSNotification) {
-        activity.stopAnimating()
-        activity.removeFromSuperview()
+        activity?.stopAnimating()
+        activity?.removeFromSuperview()
         activity = nil
     }
 

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -8,7 +8,6 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     var navigationTitle: UINavigationItem!
     var player: MPMoviePlayerController!
     var activity: UIActivityIndicatorView!
-    var aboutPopoverController: UIPopoverController!
 
     var currentEntry: DictEntry!
 
@@ -42,7 +41,6 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         view.addSubview(navigationBar)
         
         navigationTitle = UINavigationItem(title: "")
-        navigationTitle.rightBarButtonItem = UIBarButtonItem(title: "About", style: .Plain, target: self, action: "showAbout:")
         navigationBar.setItems([navigationTitle], animated: false)
 
         diagramView = DiagramView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, view.bounds.size.height / 2))
@@ -116,17 +114,4 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         }
     }
 
-    func showAbout(sender: AnyObject) {
-        if aboutPopoverController == nil {
-            let controller: AboutViewController = AboutViewController(nibName: "AboutViewController", bundle: nil)
-            aboutPopoverController = UIPopoverController(contentViewController: controller)
-        }
-
-        if aboutPopoverController.popoverVisible {
-            aboutPopoverController.dismissPopoverAnimated(true)
-        }
-        else {
-            aboutPopoverController.presentPopoverFromBarButtonItem(sender as! UIBarButtonItem, permittedArrowDirections: .Any, animated: true)
-        }
-    }
 }

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -78,10 +78,10 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     }
 
     func showEntry(notification: NSNotification) {
-        currentEntry = notification.userInfo!["entry"] as! DictEntry
-        navigationTitle.title = currentEntry.gloss
-        diagramView.showEntry(currentEntry)
-        player.view!.removeFromSuperview()
+        currentEntry = notification.userInfo?["entry"] as? DictEntry
+        navigationTitle?.title = currentEntry.gloss
+        diagramView?.showEntry(currentEntry)
+        player?.view!.removeFromSuperview()
         player = nil
     }
 

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -37,6 +37,10 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         navigationBar.autoresizingMask = .FlexibleWidth
         navigationBar.delegate = self
         view.addSubview(navigationBar)
+        
+        navigationTitle = UINavigationItem(title: "")
+        navigationTitle.rightBarButtonItem = UIBarButtonItem(title: "About", style: .Plain, target: self, action: "showAbout:")
+        navigationBar.setItems([navigationTitle], animated: false)
 
         diagramView = DiagramView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, view.bounds.size.height / 2))
         diagramView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight, .FlexibleBottomMargin]
@@ -57,14 +61,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         self.view = view
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationTitle = UINavigationItem(title: "")
-        navigationTitle.rightBarButtonItem = UIBarButtonItem(title: "About", style: .Plain, target: self, action: "showAbout:")
-        navigationBar.setItems([navigationTitle], animated: false)
-    }
-
-    override func shouldAutorotate() -> Bool {
+     override func shouldAutorotate() -> Bool {
         return true
     }
 

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -106,7 +106,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     }
 
     func playerPlaybackDidFinish(notification: NSNotification) {
-        let reason = notification.userInfo![MPMoviePlayerPlaybackDidFinishReasonUserInfoKey] as! MPMovieFinishReason
+        let reason = notification.userInfo![MPMoviePlayerPlaybackDidFinishReasonUserInfoKey] as? MPMovieFinishReason
 
         if reason == .PlaybackError {
             let alert: UIAlertView = UIAlertView(title: "Network access required", message: "Playing videos requires access to the Internet.", delegate: nil, cancelButtonTitle: "Cancel", otherButtonTitles: "")

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -14,7 +14,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "showEntry:", name: EntrySelectedName, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(DetailViewController.showEntry(_:)), name: EntrySelectedName, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerPlaybackStateDidChange:", name: MPMoviePlayerPlaybackStateDidChangeNotification, object: player)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerPlaybackDidFinish:", name: MPMoviePlayerPlaybackDidFinishNotification, object: player)
     }

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -32,7 +32,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
 
         let top_offset: CGFloat = 20
 
-        navigationBar = UINavigationBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 44))
+        navigationBar = UINavigationBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 96 - top_offset))
         navigationBar.barTintColor = AppThemePrimaryColor
         navigationBar.opaque = false
         navigationBar.autoresizingMask = .FlexibleWidth

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -43,7 +43,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         navigationTitle = UINavigationItem(title: "")
         navigationBar.setItems([navigationTitle], animated: false)
 
-        diagramView = DiagramView(frame: CGRectMake(0, top_offset + 44, view.bounds.size.width, view.bounds.size.height / 2))
+        diagramView = DiagramView(frame: CGRectMake(0, navigationBar.frame.maxY, view.bounds.size.width, view.bounds.size.height / 2))
         diagramView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight, .FlexibleBottomMargin]
         view.addSubview(diagramView)
 

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -34,7 +34,10 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         let top_offset: CGFloat = 20
 
         navigationBar = UINavigationBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 44))
+        navigationBar.barTintColor = AppThemePrimaryColor
+        navigationBar.opaque = false
         navigationBar.autoresizingMask = .FlexibleWidth
+        navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.whiteColor()]
         navigationBar.delegate = self
         view.addSubview(navigationBar)
         

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -158,6 +158,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
             self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
         }
 
+        view.backgroundColor = AppThemePrimaryLightColor
         
         searchBar = PaddedUISearchBar(frame: CGRectMake(0, onPad() ? statusBarHeight : 0, view.bounds.size.width, onPad() ? 96 : 44))
         searchBar.backgroundImage = UIImage()

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -155,6 +155,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         searchBar = PaddedUISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
         searchBar.autoresizingMask = .FlexibleWidth
         searchBar.barTintColor = AppThemePrimaryColor
+        searchBar.opaque = false
         searchBar.delegate = self
         self.view.addSubview(searchBar)
 

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -215,8 +215,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         wotdView.addSubview(wotdImageView)
         
         
-        aboutContentWebView = UIWebView.init(frame: CGRectMake(0, wotdView.bounds.maxY + 44, wotdView.frame.width, 500))
-        aboutContentWebView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        aboutContentWebView = UIWebView.init(frame: CGRectMake(0, wotdView.frame.maxY + 44, wotdView.frame.width, 500))
         aboutContentWebView.delegate = self
         
         scrollView.insertSubview(aboutContentWebView, belowSubview: wotdView)

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -145,6 +145,10 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
+    
+    func onPad()-> Bool {
+        return UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Pad
+    }
 
     // MARK View lifecycle
 

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -450,7 +450,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         let entry: DictEntry = searchResults[indexPath.row] as! DictEntry
         self.selectEntry(entry)
         searchBar.resignFirstResponder()
-        self.delegate.didSelectEntry(entry)
+        self.delegate?.didSelectEntry(entry)
     }
 
 

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -404,7 +404,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     }
 
     func selectEntry(entry: DictEntry) {
-        NSNotificationCenter.defaultCenter().postNotificationName(EntrySelectedName, object: self, userInfo: ["entry": entry])
+        NSNotificationCenter.defaultCenter().postNotificationName(EntrySelectedName, object: nil, userInfo: ["entry": entry])
     }
 
     func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -145,7 +145,13 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     // MARK View lifecycle
 
     override func loadView() {
-        self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
+        if (self.tabBarController != nil) {
+            self.view = UIView.init(frame: CGRectMake(0, 20, 320, UIScreen.mainScreen().applicationFrame.height))
+        } else {
+            self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
+        }
+
+        
         searchBar = PaddedUISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
         searchBar.autoresizingMask = .FlexibleWidth
         searchBar.barTintColor = AppThemePrimaryColor

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -181,7 +181,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         
         scrollView = UIScrollView.init(frame: searchTable.frame);
         scrollView.contentSize = CGSize.init(width: self.view.bounds.width, height: 600)
-        scrollView.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
+        scrollView.autoresizingMask = [.FlexibleHeight]
         scrollView.backgroundColor = UIColor.whiteColor()
         
         

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -167,7 +167,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), forControlEvents: .ValueChanged)
       
         self.view.addSubview(modeSwitch)
-        searchTable = UITableView(frame: CGRectMake(0, 0 + 44, view.bounds.size.width, view.bounds.size.height - (0 + 44)))
+        searchTable = UITableView(frame: CGRectMake(0, 0 + 44, view.frame.size.width, view.frame.size.height - (0 + 44)))
         searchTable.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         searchTable.rowHeight = 50
         searchTable.dataSource = self

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -24,6 +24,10 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     var subsequent_keyboard: Bool!
     var scrollView: UIScrollView!
     var aboutContentWebView: UIWebView!
+    
+    // This is a fixed default in iOS
+    var detailViewMasterWidth = CGFloat(320)
+    var statusBarHeight = CGFloat(20)
 
     // MARK: Fixed datasource initialization
     // why do they leave the first element blank?
@@ -145,29 +149,37 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     // MARK View lifecycle
 
     override func loadView() {
-        if (self.tabBarController != nil) {
-            self.view = UIView.init(frame: CGRectMake(0, 20, 320, UIScreen.mainScreen().applicationFrame.height))
+        if (onPad()) {
+            // Create search frame set to fit within the master frame of the
+            // detail view controller;
+            // @see DetailViewController
+            self.view = UIView.init(frame: CGRectMake(0, statusBarHeight, detailViewMasterWidth, UIScreen.mainScreen().applicationFrame.height))
         } else {
             self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
         }
 
         
-        searchBar = PaddedUISearchBar(frame: CGRectMake(0, 0, view.bounds.size.width, 44))
-        searchBar.autoresizingMask = .FlexibleWidth
+        searchBar = PaddedUISearchBar(frame: CGRectMake(0, onPad() ? statusBarHeight : 0, view.bounds.size.width, onPad() ? 96 : 44))
+        searchBar.backgroundImage = UIImage()
+        searchBar.autoresizingMask = [.FlexibleWidth]
+        searchBar.tintColor = AppThemePrimaryColor
+        searchBar.tintAdjustmentMode = .Normal
         searchBar.barTintColor = AppThemePrimaryColor
-        searchBar.opaque = false
+        searchBar.opaque = true
+        
         searchBar.delegate = self
         self.view.addSubview(searchBar)
 
         modeSwitch = UISegmentedControl(items: ["Abc", UIImage(named: "hands")!])
         modeSwitch.autoresizingMask = .FlexibleLeftMargin
-        modeSwitch.frame = CGRectMake(view.bounds.size.width - modeSwitch.bounds.size.width - 4, 0 + 6, modeSwitch.bounds.size.width, 32)
+        modeSwitch.frame = CGRectMake(view.bounds.size.width -
+            modeSwitch.bounds.size.width - 8, 0 + 16, modeSwitch.bounds.size.width, 32)
         modeSwitch.selectedSegmentIndex = 0
         modeSwitch.tintColor = UIColor.whiteColor();
         modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), forControlEvents: .ValueChanged)
       
         self.view.addSubview(modeSwitch)
-        searchTable = UITableView(frame: CGRectMake(0, 0 + 44, view.frame.size.width, view.frame.size.height - (0 + 44)))
+        searchTable = UITableView(frame: CGRectMake(0, onPad() ? 96 : 44, view.frame.size.width, view.frame.size.height - (0 + 44)))
         searchTable.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         searchTable.rowHeight = 50
         searchTable.dataSource = self

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -315,14 +315,14 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         navbarTitleFirstSegment.sizeToFit();
         navbarTitleSecondSegment.sizeToFit();
         
-        self.tabBarController?.navigationItem.setLeftBarButtonItems([
+        self.tabBarController!.navigationItem.setLeftBarButtonItems([
             UIBarButtonItem.init(customView: navbarTitleFirstSegment),
             UIBarButtonItem.init(customView: navbarTitleSecondSegment)
         ], animated: false)
         
         
         let navigationBarRightButtonItem = UIBarButtonItem.init(customView: modeSwitch);
-        self.tabBarController?.navigationItem.setRightBarButtonItem(navigationBarRightButtonItem, animated: false)
+        self.tabBarController!.navigationItem.setRightBarButtonItem(navigationBarRightButtonItem, animated: false)
         
         wotdGlossLabel.text = wordOfTheDay.gloss
         wotdGlossLabel.sizeToFit()
@@ -356,7 +356,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         if sender.state == .Ended {
             self.selectEntry(wordOfTheDay)
             searchBar.resignFirstResponder()
-            self.delegate.didSelectEntry(wordOfTheDay)
+            self.delegate?.didSelectEntry(wordOfTheDay)
         }
     }
 


### PR DESCRIPTION
This pull request hopefully gives us a working release that the iTunes team will approve for beta release, unblocking our testing!

After I updated the UI and workflow of the phone version of the app, the iPad layout was left in a bit of a broken state. This pull request updates the behaviour of the iPad app so that the app can be opened and used. I've made some design modifications to get it looking more like the phone app, but functionality-aside, design changes are out of scope for this phase of work, so I've not done more than I need to to get the app unbroken. I'm hoping to have some time this week to jump in and try and make some more improvements, as I know many families use this app on an iPad due to it's larger size and readability.

![simulator screen shot 12 06 2017 3 44 09 pm](https://user-images.githubusercontent.com/292020/27018640-16d6cea8-4f86-11e7-9cbb-88dadc5f7fd1.png)

![simulator screen shot 12 06 2017 3 44 16 pm](https://user-images.githubusercontent.com/292020/27018644-197f3938-4f86-11e7-9dcc-3016444782e4.png)


There's a BUNCH of things annoying me here that I'd like to fix (but don't affect the app working)

1. The blue on the search bar is  darker. There's no reason in code for it. It just is. ???
2. I'd like to fix the webview containing the about content to the bottom of the screen. I also wonder if it should go in the right hand column when there is no search (I think this is the 'out of scope' bit)
3. The layout of the main part of the screen needs some major typographical and spacing adjustments to look nicer
4. I'd like to put the "NZSL Dictionary" app title up the top left like the phone version has. It's going to be a bit of a positioning nightmare.