### PR TITLE
Implement missing init function required by iOS 8.4

### DIFF
--- a/NZSLDict/Classes/HistoryViewController.swift
+++ b/NZSLDict/Classes/HistoryViewController.swift
@@ -7,6 +7,10 @@ class HistoryViewController: UITableViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
 
     override init(style: UITableViewStyle) {
         super.init(style: style)


### PR DESCRIPTION
Without this function, the app crashes on start on iOS 8.4, as something higher in the viewcontroller hierarchy attempts to create the controller.

I've checked in the app and there doesn't seem to be any behavioural or visual changes from this init function being defined.