### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: objective-c
-osx_image: xcode8.3
-xcode_project: NZSLDict.xcodeproj 
+xcode_workspace: NZSLDict.xcworkspace
 xcode_scheme: NZSLDictTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: objective-c
-xcode_workspace: NZSLDict.xcworkspace
-xcode_scheme: NZSLDictTests
+env:
+  - CODE_SIGNING_REQUIRED=NO
+script:
+  - xcodebuild clean test -sdk iphonesimulator -project NZSLDict.xcodeproj -scheme NZSLDictTests 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+xcode_project: NZSLDict.xcodeproj 
+xcode_scheme: NZSLDictTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
+osx_image: xcode8.3
 xcode_project: NZSLDict.xcodeproj 
 xcode_scheme: NZSLDictTests

--- a/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDict.xcscheme
+++ b/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDict.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "37B3F2881512F946005F45FA"
+               BuildableName = "NZSLDict.app"
+               BlueprintName = "NZSLDict"
+               ReferencedContainer = "container:NZSLDict.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03B1C88B1EE75B0E008A875C"
+               BuildableName = "NZSLDictTests.xctest"
+               BlueprintName = "NZSLDictTests"
+               ReferencedContainer = "container:NZSLDict.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37B3F2881512F946005F45FA"
+            BuildableName = "NZSLDict.app"
+            BlueprintName = "NZSLDict"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37B3F2881512F946005F45FA"
+            BuildableName = "NZSLDict.app"
+            BlueprintName = "NZSLDict"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37B3F2881512F946005F45FA"
+            BuildableName = "NZSLDict.app"
+            BlueprintName = "NZSLDict"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      customArchiveName = "NZSLDict"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDictTests.xcscheme
+++ b/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDictTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03B1C88B1EE75B0E008A875C"
+               BuildableName = "NZSLDictTests.xctest"
+               BlueprintName = "NZSLDictTests"
+               ReferencedContainer = "container:NZSLDict.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDictTests.xcscheme
+++ b/NZSLDict.xcodeproj/xcshareddata/xcschemes/NZSLDictTests.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03B1C88B1EE75B0E008A875C"
+               BuildableName = "NZSLDictTests.xctest"
+               BlueprintName = "NZSLDictTests"
+               ReferencedContainer = "container:NZSLDict.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -23,6 +39,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37B3F2881512F946005F45FA"
+            BuildableName = "NZSLDict.app"
+            BlueprintName = "NZSLDict"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -36,6 +61,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03B1C88B1EE75B0E008A875C"
+            BuildableName = "NZSLDictTests.xctest"
+            BlueprintName = "NZSLDictTests"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03B1C88B1EE75B0E008A875C"
+            BuildableName = "NZSLDictTests.xctest"
+            BlueprintName = "NZSLDictTests"
+            ReferencedContainer = "container:NZSLDict.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Official NZSL Dictionary App for iOS devices
 
+[![Build Status](https://travis-ci.org/rabid/nzsl-dictionary-ios.svg?branch=master)](https://travis-ci.org/rabid/nzsl-dictionary-ios)
+
 This repository holds the code necessary to develop the NZSL Dictionary App for iOS. This codebase can be imported into XCode and you are invited to fork it to add features and bug fixes.
 
 The original code was developed by [Greg Hewgill](http://hewgill.com/) and generously gifted to the [Deaf Studies Research Unit](http://www.victoria.ac.nz/lals/centres-and-institutes/dsru) of [Victoria University of Wellignton](http://www.victoria.ac.nz/). It is maintained by [Rabid Technologies](http://www.rabid.co.nz/). 


### PR DESCRIPTION
This pull request adds a configuration file for Travis to run the project tests. It also adds the vanity badge to the README.

At this stage, the tests are limited to expected output tests on Dictionary keyword searches, however, the setup of the testing is such that more tests can be added to the scheme from this point and they will be automatically run by Travis.

Here is an example of a passing build: https://travis-ci.org/rabid/nzsl-dictionary-ios/builds/243500529