### PR TITLE
Guard against locationImage() returning nil

### DIFF
--- a/NZSLDict/Classes/DetailView.swift
+++ b/NZSLDict/Classes/DetailView.swift
@@ -59,6 +59,8 @@ class DetailView: UIView {
         minorView.text = entry.minor
         maoriView.text = entry.maori
         handshapeView.image = UIImage(named: entry.handshapeImage())
-        locationView.image = UIImage(named: entry.locationImage())
+        if let locationImageName = entry.locationImage() {
+            locationView.image = UIImage(named: locationImageName)
+        }
     }
 }


### PR DESCRIPTION
Objective-C is more forgiving of values that are nil - it allows more
methods to be called on it. Swift is not as forgiving, so we must guard
against the location image call being nil. It will return nil if there
is no matching location image - at this time, 'Palm' and 'Blades' are
missing locations - I have a query with the client as to whether this is
correct.