### PR TITLE
Convert Swift 2.3 to Swift 3.0 to build on Xcode > 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode8.3
 env:
   - CODE_SIGNING_REQUIRED=NO
 script:

--- a/NZSLDict.xcodeproj/project.pbxproj
+++ b/NZSLDict.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 				TargetAttributes = {
 					03B1C88B1EE75B0E008A875C = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0830;
 						TestTargetID = 37B3F2881512F946005F45FA;
 					};
 					37B3F2881512F946005F45FA = {
@@ -632,6 +633,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = nz.co.rabid.NZSLDictTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NZSLDict.app/NZSLDict";
 			};
 			name = Debug;
@@ -657,6 +659,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = nz.co.rabid.NZSLDictTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NZSLDict.app/NZSLDict";
 			};
 			name = Release;
@@ -682,6 +685,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = nz.co.rabid.NZSLDictTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NZSLDict.app/NZSLDict";
 			};
 			name = Distribution;

--- a/NZSLDict.xcodeproj/project.pbxproj
+++ b/NZSLDict.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 					};
 					37B3F2881512F946005F45FA = {
 						DevelopmentTeam = 6G3Y9JE4M4;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -736,6 +737,7 @@
 				PRODUCT_NAME = NZSLDict;
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "NZSLDict/Classes/NZSLDict-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Distribution;
@@ -829,6 +831,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "NZSLDict/Classes/NZSLDict-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -850,6 +853,7 @@
 				PRODUCT_NAME = NZSLDict;
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "NZSLDict/Classes/NZSLDict-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/NZSLDict/Classes/AboutViewController.swift
+++ b/NZSLDict/Classes/AboutViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 class AboutViewController: UIViewController, UIWebViewDelegate {
     var webView: UIWebView!
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
         self.tabBarItem = UITabBarItem(title: "About", image: UIImage(named: "info"), tag: 0)
@@ -14,10 +14,10 @@ class AboutViewController: UIViewController, UIWebViewDelegate {
     }
 
     override func loadView() {
-        webView = UIWebView(frame: UIScreen.mainScreen().bounds)
-        webView.autoresizingMask = [UIViewAutoresizing.FlexibleWidth, UIViewAutoresizing.FlexibleHeight]
+        webView = UIWebView(frame: UIScreen.main.bounds)
+        webView.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
 
-        if UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone {
+        if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.phone {
             webView.scrollView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0)
         }
 
@@ -28,36 +28,36 @@ class AboutViewController: UIViewController, UIWebViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        guard let aboutPath = NSBundle.mainBundle().pathForResource("about.html", ofType: nil) else {
+        guard let aboutPath = Bundle.main.path(forResource: "about.html", ofType: nil) else {
             print("Failed to find about.html")
             return
         }
 
-        let aboutUrl = NSURL(fileURLWithPath: aboutPath)
-        let request = NSURLRequest(URL: aboutUrl)
+        let aboutUrl = URL(fileURLWithPath: aboutPath)
+        let request = URLRequest(url: aboutUrl)
         webView.loadRequest(request)
     }
 
-    override func shouldAutorotate() -> Bool {
+    override var shouldAutorotate : Bool {
         return true
     }
 
-    func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
-        if request.URL!.fileURL {
+    func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        if request.url!.isFileURL {
             return true
         }
 
-        if request.URL!.scheme == "follow" {
+        if request.url!.scheme == "follow" {
             openTwitterClientForUserName("NZSLDict")
             return false
         }
 
-        UIApplication.sharedApplication().openURL(request.URL!)
+        UIApplication.shared.openURL(request.url!)
         return false
     }
 
     // https://gist.github.com/vhbit/958738
-    func openTwitterClientForUserName(userName: String) -> Bool {
+    func openTwitterClientForUserName(_ userName: String) -> Bool {
         let urls = [
             "twitter:@{username}", // Twitter
             "tweetbot:///user_profile/{username}", // TweetBot
@@ -73,11 +73,11 @@ class AboutViewController: UIViewController, UIWebViewDelegate {
             "http://twitter.com/{username}", // Web fallback,
         ]
 
-        let application: UIApplication = UIApplication.sharedApplication()
+        let application: UIApplication = UIApplication.shared
 
         for candidate in urls {
-            let urlString = candidate.stringByReplacingOccurrencesOfString("{username}", withString:userName)
-            if let url = NSURL(string: urlString) {
+            let urlString = candidate.replacingOccurrences(of: "{username}", with:userName)
+            if let url = URL(string: urlString) {
                 print("testing \(url)")
                 if application.canOpenURL(url) {
                     print("we can open \(url)")

--- a/NZSLDict/Classes/AppDelegate.swift
+++ b/NZSLDict/Classes/AppDelegate.swift
@@ -4,12 +4,12 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         var rootViewController: UIViewController!
 
-        self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
+        self.window = UIWindow(frame: UIScreen.main.bounds)
 
-        if UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone {
+        if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.phone {
             rootViewController = ViewControllerPhone()
         } else {
             rootViewController = ViewControllerPad()
@@ -19,10 +19,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         let navigationController: UINavigationController = UINavigationController.init(rootViewController: rootViewController)
-        navigationController.navigationBar.barStyle = UIBarStyle.Black;
-        navigationController.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.whiteColor()]
+        navigationController.navigationBar.barStyle = UIBarStyle.black;
+        navigationController.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         navigationController.navigationBar.barTintColor = AppThemePrimaryColor;
-        navigationController.navigationBar.translucent = false
+        navigationController.navigationBar.isTranslucent = false
         
     
         self.window!.rootViewController = navigationController
@@ -32,25 +32,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         // Saves changes in the application's managed object context before the application terminates.
     }

--- a/NZSLDict/Classes/DetailView.swift
+++ b/NZSLDict/Classes/DetailView.swift
@@ -22,39 +22,39 @@ class DetailView: UIView {
 
     // the convenience initializer provides a default frame
     convenience init() {
-        self.init(frame: CGRectZero) // calls the designated initializer in this file!
+        self.init(frame: CGRect.zero) // calls the designated initializer in this file!
     }
 
     func setupView() {
-        self.backgroundColor = UIColor.whiteColor()
+        self.backgroundColor = UIColor.white
 
-        glossView = UILabel(frame: CGRectMake(DetailView.inset, DetailView.inset, self.bounds.size.width - DetailView.inset * 2 - 120, 20))
-        glossView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
-        glossView.font = UIFont.boldSystemFontOfSize(18)
+        glossView = UILabel(frame: CGRect(x: DetailView.inset, y: DetailView.inset, width: self.bounds.size.width - DetailView.inset * 2 - 120, height: 20))
+        glossView.autoresizingMask = UIViewAutoresizing.flexibleWidth
+        glossView.font = UIFont.boldSystemFont(ofSize: 18)
         self.addSubview(glossView)
 
-        minorView = UILabel(frame: CGRectMake(DetailView.inset, DetailView.inset+20, self.bounds.size.width-DetailView.inset*2-120, 20))
-        minorView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
-        minorView.font = UIFont.systemFontOfSize(15)
+        minorView = UILabel(frame: CGRect(x: DetailView.inset, y: DetailView.inset+20, width: self.bounds.size.width-DetailView.inset*2-120, height: 20))
+        minorView.autoresizingMask = UIViewAutoresizing.flexibleWidth
+        minorView.font = UIFont.systemFont(ofSize: 15)
         self.addSubview(minorView)
 
-        maoriView = UILabel(frame: CGRectMake(DetailView.inset, DetailView.inset+40, self.bounds.size.width-DetailView.inset*2-120, 20))
-        maoriView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
-        maoriView.font = UIFont.italicSystemFontOfSize(15)
+        maoriView = UILabel(frame: CGRect(x: DetailView.inset, y: DetailView.inset+40, width: self.bounds.size.width-DetailView.inset*2-120, height: 20))
+        maoriView.autoresizingMask = UIViewAutoresizing.flexibleWidth
+        maoriView.font = UIFont.italicSystemFont(ofSize: 15)
         self.addSubview(maoriView)
 
-        handshapeView = UIImageView(frame: CGRectMake(self.bounds.size.width-DetailView.inset-120, DetailView.inset, 60, 60))
-        handshapeView.autoresizingMask = UIViewAutoresizing.FlexibleLeftMargin
-        handshapeView.contentMode = UIViewContentMode.ScaleAspectFit
+        handshapeView = UIImageView(frame: CGRect(x: self.bounds.size.width-DetailView.inset-120, y: DetailView.inset, width: 60, height: 60))
+        handshapeView.autoresizingMask = UIViewAutoresizing.flexibleLeftMargin
+        handshapeView.contentMode = UIViewContentMode.scaleAspectFit
         self.addSubview(handshapeView)
 
-        locationView = UIImageView(frame: CGRectMake(self.bounds.size.width-DetailView.inset-60, DetailView.inset, 60, 60))
-        locationView.autoresizingMask = UIViewAutoresizing.FlexibleLeftMargin
-        locationView.contentMode = UIViewContentMode.ScaleAspectFit
+        locationView = UIImageView(frame: CGRect(x: self.bounds.size.width-DetailView.inset-60, y: DetailView.inset, width: 60, height: 60))
+        locationView.autoresizingMask = UIViewAutoresizing.flexibleLeftMargin
+        locationView.contentMode = UIViewContentMode.scaleAspectFit
         self.addSubview(locationView)
     }
 
-    func showEntry(entry: DictEntry) {
+    func showEntry(_ entry: DictEntry) {
         glossView.text = entry.gloss
         minorView.text = entry.minor
         maoriView.text = entry.maori

--- a/NZSLDict/Classes/DetailViewController.swift
+++ b/NZSLDict/Classes/DetailViewController.swift
@@ -14,11 +14,11 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
 
     var currentEntry: DictEntry!
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(DetailViewController.showEntry(_:)), name: EntrySelectedName, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerPlaybackStateDidChange:", name: MPMoviePlayerPlaybackStateDidChangeNotification, object: player)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerPlaybackDidFinish:", name: MPMoviePlayerPlaybackDidFinishNotification, object: player)
+        NotificationCenter.default.addObserver(self, selector: #selector(DetailViewController.showEntry(_:)), name: NSNotification.Name(rawValue: EntrySelectedName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(DetailViewController.playerPlaybackStateDidChange(_:)), name: NSNotification.Name.MPMoviePlayerPlaybackStateDidChange, object: player)
+        NotificationCenter.default.addObserver(self, selector: #selector(DetailViewController.playerPlaybackDidFinish(_:)), name: NSNotification.Name.MPMoviePlayerPlaybackDidFinish, object: player)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -26,46 +26,46 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     }
 
     deinit {
-       NSNotificationCenter.defaultCenter().removeObserver(self)
+       NotificationCenter.default.removeObserver(self)
         reachability?.stopNotifier()
         reachability = nil
     }
 
     override func loadView() {
-        let view: UIView = UIView(frame: UIScreen.mainScreen().bounds)
-        view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        let view: UIView = UIView(frame: UIScreen.main.bounds)
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         let top_offset: CGFloat = 20
 
-        navigationBar = UINavigationBar(frame: CGRectMake(0, top_offset, view.bounds.size.width, 96 - top_offset))
+        navigationBar = UINavigationBar(frame: CGRect(x: 0, y: top_offset, width: view.bounds.size.width, height: 96 - top_offset))
         navigationBar.barTintColor = AppThemePrimaryColor
-        navigationBar.opaque = false
-        navigationBar.autoresizingMask = .FlexibleWidth
-        navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.whiteColor()]
+        navigationBar.isOpaque = false
+        navigationBar.autoresizingMask = .flexibleWidth
+        navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         navigationBar.delegate = self
         view.addSubview(navigationBar)
         
         navigationTitle = UINavigationItem(title: "NZSL Dictionary")
         navigationBar.setItems([navigationTitle], animated: false)
 
-        diagramView = DiagramView(frame: CGRectMake(0, navigationBar.frame.maxY, view.bounds.size.width, view.bounds.size.height / 2))
-        diagramView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight, .FlexibleBottomMargin]
+        diagramView = DiagramView(frame: CGRect(x: 0, y: navigationBar.frame.maxY, width: view.bounds.size.width, height: view.bounds.size.height / 2))
+        diagramView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleBottomMargin]
         view.addSubview(diagramView)
 
-        videoView = UIView(frame: CGRectMake(0, top_offset + 44 + view.bounds.size.height / 2, view.bounds.size.width, view.bounds.size.height - (top_offset + 44 + view.bounds.size.height / 2)))
-        videoView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight, .FlexibleTopMargin]
-        videoView.backgroundColor = UIColor.blackColor()
+        videoView = UIView(frame: CGRect(x: 0, y: top_offset + 44 + view.bounds.size.height / 2, width: view.bounds.size.width, height: view.bounds.size.height - (top_offset + 44 + view.bounds.size.height / 2)))
+        videoView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleTopMargin]
+        videoView.backgroundColor = UIColor.black
         view.addSubview(videoView)
 
-        playButton = UIButton(type: .RoundedRect)
-        playButton.frame = CGRectMake(0, (videoView.bounds.size.height - 40) / 2, videoView.bounds.width, 40)
-        playButton.titleLabel?.textAlignment = .Center
-        playButton.autoresizingMask = [.FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin, .FlexibleBottomMargin]
-        playButton.setTitle("Play Video", forState: .Normal)
-        playButton.setTitle("Playing videos requires access to the Internet.", forState: .Disabled)
-        playButton.setTitleColor(UIColor.whiteColor(), forState: .Disabled)
+        playButton = UIButton(type: .roundedRect)
+        playButton.frame = CGRect(x: 0, y: (videoView.bounds.size.height - 40) / 2, width: videoView.bounds.width, height: 40)
+        playButton.titleLabel?.textAlignment = .center
+        playButton.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
+        playButton.setTitle("Play Video", for: UIControlState())
+        playButton.setTitle("Playing videos requires access to the Internet.", for: .disabled)
+        playButton.setTitleColor(UIColor.white, for: .disabled)
         
-        playButton.addTarget(self, action: "startPlayer:", forControlEvents: .TouchUpInside)
+        playButton.addTarget(self, action: #selector(DetailViewController.startPlayer(_:)), for: .touchUpInside)
         videoView.addSubview(playButton)
         
         setupNetworkStatusMonitoring()
@@ -73,24 +73,24 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         self.view = view
     }
 
-     override func shouldAutorotate() -> Bool {
+     override var shouldAutorotate : Bool {
         return true
     }
 
-    override func didRotateFromInterfaceOrientation(fromInterfaceOrientation: UIInterfaceOrientation) {
+    override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
         if player == nil { return }
         player.view!.frame = videoView.frame
     }
 
-    func splitViewController(svc: UISplitViewController, shouldHideViewController vc: UIViewController, inOrientation orientation: UIInterfaceOrientation) -> Bool {
+    func splitViewController(_ svc: UISplitViewController, shouldHide vc: UIViewController, in orientation: UIInterfaceOrientation) -> Bool {
         return false
     }
 
-    func positionForBar(bar: UIBarPositioning) -> UIBarPosition {
-        return .TopAttached
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
     }
 
-    func showEntry(notification: NSNotification) {
+    func showEntry(_ notification: Notification) {
         currentEntry = notification.userInfo?["entry"] as? DictEntry
         navigationTitle?.title = currentEntry.gloss
         diagramView?.showEntry(currentEntry)
@@ -99,25 +99,25 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
     }
     
     func setupNetworkStatusMonitoring() {
-        reachability = Reachability.reachabilityForInternetConnection()
+        reachability = Reachability.forInternetConnection()
         
         reachability!.reachableBlock = { (reach: Reachability?) -> Void in
             // this is called on a background thread, but UI updates must
             // be on the main thread, like this:
-            dispatch_async(dispatch_get_main_queue()) {
-                self.playButton.enabled = true
+            DispatchQueue.main.async {
+                self.playButton.isEnabled = true
             }
         }
         
         reachability!.unreachableBlock = { (reach: Reachability?) -> Void in
             // this is called on a background thread, but UI updates must
             // be on the main thread, like this:
-            dispatch_async(dispatch_get_main_queue()) {
-                self.playButton.enabled = false
+            DispatchQueue.main.async {
+                self.playButton.isEnabled = false
             }
         }
         
-        self.playButton.enabled = reachability?.currentReachabilityStatus() != .NotReachable
+        self.playButton.isEnabled = reachability?.currentReachabilityStatus() != .NotReachable
         
     }
     
@@ -126,29 +126,29 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIN
         self.reachability!.startNotifier()
     }
 
-    @IBAction func startPlayer(sender: AnyObject) {
-        player = MPMoviePlayerController(contentURL: NSURL(string: currentEntry.video)!)
+    @IBAction func startPlayer(_ sender: AnyObject) {
+        player = MPMoviePlayerController(contentURL: URL(string: currentEntry.video)!)
         player.prepareToPlay()
         player.view!.frame = videoView.bounds
         videoView.addSubview(player.view!)
         player.play()
 
-        activity = UIActivityIndicatorView(activityIndicatorStyle: .WhiteLarge)
+        activity = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
         videoView.addSubview(activity)
-        activity.frame = CGRectOffset(activity.frame, (CGRectGetWidth(videoView.bounds) - CGRectGetWidth(activity.bounds)) / 2, (CGRectGetHeight(videoView.bounds) - CGRectGetHeight(activity.bounds)) / 2)
+        activity.frame = activity.frame.offsetBy(dx: (videoView.bounds.width - activity.bounds.width) / 2, dy: (videoView.bounds.height - activity.bounds.height) / 2)
         activity.startAnimating()
     }
 
-    func playerPlaybackStateDidChange(notification: NSNotification) {
+    func playerPlaybackStateDidChange(_ notification: Notification) {
         activity?.stopAnimating()
         activity?.removeFromSuperview()
         activity = nil
     }
 
-    func playerPlaybackDidFinish(notification: NSNotification) {
+    func playerPlaybackDidFinish(_ notification: Notification) {
         let reason = notification.userInfo![MPMoviePlayerPlaybackDidFinishReasonUserInfoKey] as? MPMovieFinishReason
 
-        if reason == .PlaybackError {
+        if reason == .playbackError {
             let alert: UIAlertView = UIAlertView(title: "Network access required", message: "Playing videos requires access to the Internet.", delegate: nil, cancelButtonTitle: "Cancel", otherButtonTitles: "")
             alert.show()
         }

--- a/NZSLDict/Classes/DiagramView.swift
+++ b/NZSLDict/Classes/DiagramView.swift
@@ -7,17 +7,17 @@ class DiagramView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.autoresizingMask = [UIViewAutoresizing.FlexibleWidth, UIViewAutoresizing.FlexibleHeight]
+        self.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
 
-        detailView = DetailView(frame: CGRectMake(0, 0, self.bounds.size.width, DetailView.height))
-        detailView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
+        detailView = DetailView(frame: CGRect(x: 0, y: 0, width: self.bounds.size.width, height: DetailView.height))
+        detailView.autoresizingMask = UIViewAutoresizing.flexibleWidth
 
         self.addSubview(detailView)
 
-        imageView = UIImageView(frame: CGRectMake(0, DetailView.height, self.bounds.size.width, self.bounds.size.height-DetailView.height))
-        imageView.autoresizingMask = [UIViewAutoresizing.FlexibleWidth, UIViewAutoresizing.FlexibleHeight]
-        imageView.backgroundColor = UIColor.whiteColor()
-        imageView.contentMode = UIViewContentMode.ScaleAspectFit
+        imageView = UIImageView(frame: CGRect(x: 0, y: DetailView.height, width: self.bounds.size.width, height: self.bounds.size.height-DetailView.height))
+        imageView.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
+        imageView.backgroundColor = UIColor.white
+        imageView.contentMode = UIViewContentMode.scaleAspectFit
 
         self.addSubview(imageView)
     }
@@ -26,7 +26,7 @@ class DiagramView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func showEntry(entry: DictEntry) {
+    func showEntry(_ entry: DictEntry) {
         detailView.showEntry(entry)
         imageView.image = UIImage(named: entry.image)
     }

--- a/NZSLDict/Classes/DiagramViewController.swift
+++ b/NZSLDict/Classes/DiagramViewController.swift
@@ -5,10 +5,10 @@ class DiagramViewController: UIViewController, UISearchBarDelegate {
     var currentEntry: DictEntry!
     var diagramView: DiagramView!
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         self.tabBarItem = UITabBarItem(title: "Diagram", image: UIImage(named: "hands"), tag: 0)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "showEntry:", name: EntrySelectedName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(DiagramViewController.showEntry(_:)), name: NSNotification.Name(rawValue: EntrySelectedName), object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -16,34 +16,34 @@ class DiagramViewController: UIViewController, UISearchBarDelegate {
     }
 
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func loadView() {
-        let view: UIView = UIView(frame: UIScreen.mainScreen().bounds)
-        view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        let view: UIView = UIView(frame: UIScreen.main.bounds)
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
-        diagramView = DiagramView(frame: CGRectMake(0, 0, view.bounds.size.width, view.bounds.size.height))
+        diagramView = DiagramView(frame: CGRect(x: 0, y: 0, width: view.bounds.size.width, height: view.bounds.size.height))
         view.addSubview(diagramView)
         self.view = view
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if self.respondsToSelector("edgesForExtendedLayout") {
-            self.edgesForExtendedLayout = .None
+        if self.responds(to: #selector(getter: UIViewController.edgesForExtendedLayout)) {
+            self.edgesForExtendedLayout = UIRectEdge()
         }
     }
     
-    func selectSearchMode(sender: UISegmentedControl) {
+    func selectSearchMode(_ sender: UISegmentedControl) {
             self.tabBarController?.selectedIndex = 0
     }
 
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         self.showCurrentEntry()
     }
 
-    func showEntry(notification: NSNotification) {
+    func showEntry(_ notification: Notification) {
         currentEntry = notification.userInfo!["entry"] as! DictEntry
         if diagramView == nil {
             return

--- a/NZSLDict/Classes/HistoryViewController.swift
+++ b/NZSLDict/Classes/HistoryViewController.swift
@@ -8,23 +8,23 @@ class HistoryViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
     override init(style: UITableViewStyle) {
         super.init(style: style)
-        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.MostRecent, tag: 0)
+        self.tabBarItem = UITabBarItem(tabBarSystemItem: UITabBarSystemItem.mostRecent, tag: 0)
             
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "addEntry:", name: EntrySelectedName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(HistoryViewController.addEntry(_:)), name: NSNotification.Name(rawValue: EntrySelectedName), object: nil)
     }
 
     convenience init() {
-        self.init(style: UITableViewStyle.Plain)
+        self.init(style: UITableViewStyle.plain)
     }
 
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLoad() {
@@ -33,7 +33,7 @@ class HistoryViewController: UITableViewController {
         self.tableView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0)
     }
 
-    func addEntry(notification: NSNotification) {
+    func addEntry(_ notification: Notification) {
 
         guard let userInfo = notification.userInfo else {
             fatalError("Got not userInfo dictionary")
@@ -46,12 +46,12 @@ class HistoryViewController: UITableViewController {
         }
 
         // if the current entry is in the history array then remove it
-        if let i = history.indexOf(entry) {
-            history.removeAtIndex(i)
+        if let i = history.index(of: entry) {
+            history.remove(at: i)
         }
 
         // insert the current entry at the start of the history array
-        history.insert(entry, atIndex: 0)
+        history.insert(entry, at: 0)
 
         // Keep the history array to the desired maximum length
         while (history.count > 100) {
@@ -63,28 +63,28 @@ class HistoryViewController: UITableViewController {
 
     // MARK: Table view data source
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return history.count
     }
 
 
     // MARK: Table view delegate
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         let cellIdentifier = "Cell"
         let entry: DictEntry = history[indexPath.row]
 
-        var cell: UITableViewCell? = tableView.dequeueReusableCellWithIdentifier(cellIdentifier)
+        var cell: UITableViewCell? = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)
 
         if cell == nil {
-            cell = UITableViewCell(style: UITableViewCellStyle.Subtitle, reuseIdentifier: cellIdentifier)
-            let iv: UIImageView = UIImageView(frame: CGRectMake(0, 2, tableView.rowHeight*2, tableView.rowHeight-4))
-            iv.contentMode = UIViewContentMode.ScaleAspectFit
+            cell = UITableViewCell(style: UITableViewCellStyle.subtitle, reuseIdentifier: cellIdentifier)
+            let iv: UIImageView = UIImageView(frame: CGRect(x: 0, y: 2, width: tableView.rowHeight*2, height: tableView.rowHeight-4))
+            iv.contentMode = UIViewContentMode.scaleAspectFit
             cell!.accessoryView = iv
         }
 
@@ -101,14 +101,14 @@ class HistoryViewController: UITableViewController {
         return cell!
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let dictEntryFromHistory = history[indexPath.row]
         let userInfo = [
             "entry": dictEntryFromHistory,
             "no_add_history": "no_add"
-        ]
+        ] as [String : Any]
 
-        NSNotificationCenter.defaultCenter().postNotificationName(EntrySelectedName, object: self, userInfo: userInfo)
+        NotificationCenter.default.post(name: Notification.Name(rawValue: EntrySelectedName), object: self, userInfo: userInfo)
         self.delegate?.didSelectEntry(dictEntryFromHistory)
     }
 }

--- a/NZSLDict/Classes/SearchViewController.swift
+++ b/NZSLDict/Classes/SearchViewController.swift
@@ -128,9 +128,9 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
     // MARK: Initializers
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        self.tabBarItem = UITabBarItem(tabBarSystemItem: .Search, tag: 0)
+        self.tabBarItem = UITabBarItem(tabBarSystemItem: .search, tag: 0)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -143,11 +143,11 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     //     NSNotificationCenter.defaultCenter().removeObserver(self)
     // }
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
     
     func onPad()-> Bool {
-        return UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Pad
+        return UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad
     }
 
     // MARK View lifecycle
@@ -157,83 +157,83 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
             // Create search frame set to fit within the master frame of the
             // detail view controller;
             // @see DetailViewController
-            self.view = UIView.init(frame: CGRectMake(0, statusBarHeight, detailViewMasterWidth, UIScreen.mainScreen().applicationFrame.height))
+            self.view = UIView.init(frame: CGRect(x: 0, y: statusBarHeight, width: detailViewMasterWidth, height: UIScreen.main.applicationFrame.height))
         } else {
-            self.view = UIView.init(frame: UIScreen.mainScreen().applicationFrame)
+            self.view = UIView.init(frame: UIScreen.main.applicationFrame)
         }
 
         view.backgroundColor = AppThemePrimaryLightColor
         
-        searchBar = PaddedUISearchBar(frame: CGRectMake(0, onPad() ? statusBarHeight : 0, view.bounds.size.width, onPad() ? 96 : 44))
+        searchBar = PaddedUISearchBar(frame: CGRect(x: 0, y: onPad() ? statusBarHeight : 0, width: view.bounds.size.width, height: onPad() ? 96 : 44))
         searchBar.backgroundImage = UIImage()
-        searchBar.autoresizingMask = [.FlexibleWidth]
+        searchBar.autoresizingMask = [.flexibleWidth]
         searchBar.tintColor = AppThemePrimaryColor
-        searchBar.tintAdjustmentMode = .Normal
+        searchBar.tintAdjustmentMode = .normal
         searchBar.barTintColor = AppThemePrimaryColor
-        searchBar.opaque = true
+        searchBar.isOpaque = true
         
         searchBar.delegate = self
         self.view.addSubview(searchBar)
 
         modeSwitch = UISegmentedControl(items: ["Abc", UIImage(named: "hands")!])
-        modeSwitch.autoresizingMask = .FlexibleLeftMargin
-        modeSwitch.frame = CGRectMake(view.bounds.size.width -
-            modeSwitch.bounds.size.width - 8, 0 + 16, modeSwitch.bounds.size.width, 32)
+        modeSwitch.autoresizingMask = .flexibleLeftMargin
+        modeSwitch.frame = CGRect(x: view.bounds.size.width -
+            modeSwitch.bounds.size.width - 8, y: 0 + 16, width: modeSwitch.bounds.size.width, height: 32)
         modeSwitch.selectedSegmentIndex = 0
-        modeSwitch.tintColor = UIColor.whiteColor();
-        modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), forControlEvents: .ValueChanged)
+        modeSwitch.tintColor = UIColor.white;
+        modeSwitch.addTarget(self, action: #selector(SearchViewController.selectSearchMode(_:)), for: .valueChanged)
       
         self.view.addSubview(modeSwitch)
-        searchTable = UITableView(frame: CGRectMake(0, onPad() ? 96 : 44, view.frame.size.width, view.frame.size.height - (0 + 44)))
-        searchTable.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        searchTable = UITableView(frame: CGRect(x: 0, y: onPad() ? 96 : 44, width: view.frame.size.width, height: view.frame.size.height - (0 + 44)))
+        searchTable.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         searchTable.rowHeight = 50
         searchTable.dataSource = self
         searchTable.delegate = self
         
         view.addSubview(searchTable)
-        swipeRecognizer = UISwipeGestureRecognizer(target: self, action: "hideKeyboard")
-        swipeRecognizer.direction = [.Up, .Down]
+        swipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(SearchViewController.hideKeyboard))
+        swipeRecognizer.direction = [.up, .down]
         swipeRecognizer.delegate = self
         searchTable.addGestureRecognizer(swipeRecognizer)
         
         scrollView = UIScrollView.init(frame: searchTable.frame);
         scrollView.contentSize = CGSize.init(width: self.view.bounds.width, height: 600)
-        scrollView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        scrollView.backgroundColor = UIColor.whiteColor()
+        scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        scrollView.backgroundColor = UIColor.white
         
         
         
-        wotdView = UIView.init(frame: CGRectMake(0, 0, self.view.frame.width, 125))
-        wotdView.autoresizingMask = .FlexibleWidth
-        wotdView.backgroundColor = UIColor.whiteColor()
+        wotdView = UIView.init(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 125))
+        wotdView.autoresizingMask = .flexibleWidth
+        wotdView.backgroundColor = UIColor.white
         
-        wotdLabel = UILabel(frame: CGRectMake(16, 16, wotdView.bounds.size.width * 0.7, 20))
-        wotdLabel.autoresizingMask = .FlexibleHeight
+        wotdLabel = UILabel(frame: CGRect(x: 16, y: 16, width: wotdView.bounds.size.width * 0.7, height: 20))
+        wotdLabel.autoresizingMask = .flexibleHeight
         wotdLabel.text = "Word of the day"
-        wotdLabel.font = UIFont.systemFontOfSize(14)
+        wotdLabel.font = UIFont.systemFont(ofSize: 14)
         wotdLabel.textColor = AppSecondaryTextColour
         wotdView.addSubview(wotdLabel)
         
-        wotdGlossLabel = UILabel(frame: CGRectMake(16, 40, wotdView.bounds.size.width * 0.6, 24))
-        wotdGlossLabel.autoresizingMask = .FlexibleHeight
+        wotdGlossLabel = UILabel(frame: CGRect(x: 16, y: 40, width: wotdView.bounds.size.width * 0.6, height: 24))
+        wotdGlossLabel.autoresizingMask = .flexibleHeight
         wotdGlossLabel.numberOfLines = 0
-        wotdGlossLabel.font = UIFont.systemFontOfSize(20)
-        wotdGlossLabel.textColor = UIColor.blackColor();
+        wotdGlossLabel.font = UIFont.systemFont(ofSize: 20)
+        wotdGlossLabel.textColor = UIColor.black;
         wotdView.addSubview(wotdGlossLabel)
 
 
 
-        wotdImageView = UIImageView(frame: CGRectMake(wotdView.bounds.width * 0.7, 0, wotdView.bounds.width * 0.3 - 16, 125))
-        wotdImageView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        wotdImageView.backgroundColor = UIColor.whiteColor()
-        wotdImageView.contentMode = .ScaleAspectFit
-        wotdImageView.userInteractionEnabled = true
-        wotdView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: "selectWotd:"))
+        wotdImageView = UIImageView(frame: CGRect(x: wotdView.bounds.width * 0.7, y: 0, width: wotdView.bounds.width * 0.3 - 16, height: 125))
+        wotdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        wotdImageView.backgroundColor = UIColor.white
+        wotdImageView.contentMode = .scaleAspectFit
+        wotdImageView.isUserInteractionEnabled = true
+        wotdView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(SearchViewController.selectWotd(_:))))
         wotdView.addSubview(wotdImageView)
         
         
-        aboutContentWebView = UIWebView.init(frame: CGRectMake(0, wotdView.frame.maxY + 44, wotdView.frame.width, 500))
-        aboutContentWebView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        aboutContentWebView = UIWebView.init(frame: CGRect(x: 0, y: wotdView.frame.maxY + 44, width: wotdView.frame.width, height: 500))
+        aboutContentWebView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         aboutContentWebView.delegate = self
         
         scrollView.insertSubview(aboutContentWebView, belowSubview: wotdView)
@@ -242,50 +242,50 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         self.view.addSubview(scrollView)
 
         
-        searchSelectorView = UIView(frame: CGRectMake(0, 0, view.bounds.size.width, 200))
-        searchSelectorView.autoresizingMask = .FlexibleWidth
+        searchSelectorView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.size.width, height: 200))
+        searchSelectorView.autoresizingMask = .flexibleWidth
 
-        let handshapeLabel: UILabel = UILabel(frame: CGRectMake(0, 0, view.bounds.size.width, 20))
-        handshapeLabel.autoresizingMask = .FlexibleWidth
-        handshapeLabel.backgroundColor = UIColor.lightGrayColor()
-        handshapeLabel.textColor = UIColor.whiteColor()
-        handshapeLabel.shadowColor = UIColor.grayColor()
-        handshapeLabel.shadowOffset = CGSizeMake(0, 1)
-        handshapeLabel.font = UIFont.boldSystemFontOfSize(16)
+        let handshapeLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: view.bounds.size.width, height: 20))
+        handshapeLabel.autoresizingMask = .flexibleWidth
+        handshapeLabel.backgroundColor = UIColor.lightGray
+        handshapeLabel.textColor = UIColor.white
+        handshapeLabel.shadowColor = UIColor.gray
+        handshapeLabel.shadowOffset = CGSize(width: 0, height: 1)
+        handshapeLabel.font = UIFont.boldSystemFont(ofSize: 16)
         handshapeLabel.text = "  Handshape"
         searchSelectorView.addSubview(handshapeLabel)
 
         let hslayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
-        hslayout.scrollDirection = .Horizontal
-        hslayout.itemSize = CGSizeMake(80, 80)
-        handshapeSelector = UICollectionView(frame: CGRectMake(0, 20, view.bounds.size.width, 80), collectionViewLayout: hslayout)
-        handshapeSelector.autoresizingMask = .FlexibleWidth
-        handshapeSelector.registerClass(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeAnyCellIdentifier)
-        handshapeSelector.registerClass(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeIconCellIdentifier)
-        handshapeSelector.backgroundColor = UIColor.whiteColor()
+        hslayout.scrollDirection = .horizontal
+        hslayout.itemSize = CGSize(width: 80, height: 80)
+        handshapeSelector = UICollectionView(frame: CGRect(x: 0, y: 20, width: view.bounds.size.width, height: 80), collectionViewLayout: hslayout)
+        handshapeSelector.autoresizingMask = .flexibleWidth
+        handshapeSelector.register(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeAnyCellIdentifier)
+        handshapeSelector.register(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeIconCellIdentifier)
+        handshapeSelector.backgroundColor = UIColor.white
         handshapeSelector.scrollsToTop = false
         handshapeSelector.dataSource = self
         handshapeSelector.delegate = self
         searchSelectorView.addSubview(handshapeSelector)
 
-        let locationLabel: UILabel = UILabel(frame: CGRectMake(0, 100, view.bounds.size.width, 20))
-        locationLabel.autoresizingMask = .FlexibleWidth
-        locationLabel.backgroundColor = UIColor.lightGrayColor()
-        locationLabel.textColor = UIColor.whiteColor()
-        locationLabel.shadowColor = UIColor.grayColor()
-        locationLabel.shadowOffset = CGSizeMake(0, 1)
-        locationLabel.font = UIFont.boldSystemFontOfSize(16)
+        let locationLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 100, width: view.bounds.size.width, height: 20))
+        locationLabel.autoresizingMask = .flexibleWidth
+        locationLabel.backgroundColor = UIColor.lightGray
+        locationLabel.textColor = UIColor.white
+        locationLabel.shadowColor = UIColor.gray
+        locationLabel.shadowOffset = CGSize(width: 0, height: 1)
+        locationLabel.font = UIFont.boldSystemFont(ofSize: 16)
         locationLabel.text = "  Location"
         searchSelectorView.addSubview(locationLabel)
 
         let loclayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
-        loclayout.scrollDirection = .Horizontal
-        loclayout.itemSize = CGSizeMake(80, 80)
-        locationSelector = UICollectionView(frame: CGRectMake(0, 120, view.bounds.size.width, 80), collectionViewLayout: loclayout)
-        locationSelector.autoresizingMask = .FlexibleWidth
-        locationSelector.registerClass(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeAnyCellIdentifier)
-        locationSelector.registerClass(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeIconCellIdentifier)
-        locationSelector.backgroundColor = UIColor.whiteColor()
+        loclayout.scrollDirection = .horizontal
+        loclayout.itemSize = CGSize(width: 80, height: 80)
+        locationSelector = UICollectionView(frame: CGRect(x: 0, y: 120, width: view.bounds.size.width, height: 80), collectionViewLayout: loclayout)
+        locationSelector.autoresizingMask = .flexibleWidth
+        locationSelector.register(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeAnyCellIdentifier)
+        locationSelector.register(UICollectionViewCell.self, forCellWithReuseIdentifier: HandshapeIconCellIdentifier)
+        locationSelector.backgroundColor = UIColor.white
         locationSelector.scrollsToTop = false
         locationSelector.dataSource = self
         locationSelector.delegate = self
@@ -295,17 +295,17 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if self.respondsToSelector("edgesForExtendedLayout") {
-            self.edgesForExtendedLayout = .None
+        if self.responds(to: #selector(getter: UIViewController.edgesForExtendedLayout)) {
+            self.edgesForExtendedLayout = UIRectEdge()
         }
         
-        guard let aboutPath = NSBundle.mainBundle().pathForResource("about.html", ofType: nil) else {
+        guard let aboutPath = Bundle.main.path(forResource: "about.html", ofType: nil) else {
             print("Failed to find about.html")
             return
         }
         
-        let aboutUrl = NSURL(fileURLWithPath: aboutPath)
-        let request = NSURLRequest(URL: aboutUrl)
+        let aboutUrl = URL(fileURLWithPath: aboutPath)
+        let request = URLRequest(url: aboutUrl)
         aboutContentWebView.loadRequest(request)
 
 
@@ -316,10 +316,10 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         let navbarTitleFirstSegment = UILabel()
         let navbarTitleSecondSegment = UILabel()
         
-        navbarTitleFirstSegment.textColor = UIColor.whiteColor();
-        navbarTitleSecondSegment.textColor = UIColor.whiteColor();
+        navbarTitleFirstSegment.textColor = UIColor.white;
+        navbarTitleSecondSegment.textColor = UIColor.white;
         
-        if navbarTitleFirstSegment.respondsToSelector("setAttributedText:") {
+        if navbarTitleFirstSegment.responds(to: #selector(setter: UITextField.attributedText)) {
             
             let navbarTitleFirstSegmentText = NSMutableAttributedString(string: "NZSL", attributes: [NSFontAttributeName: UIFont.init(name: "Montserrat-Bold", size: 22)!])
             let navbarTitleSecondSegmentText = NSMutableAttributedString(string: "dictionary", attributes: [NSFontAttributeName: UIFont.init(name: "Montserrat-Italic", size: 22)!])
@@ -342,7 +342,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         
         
         let navigationBarRightButtonItem = UIBarButtonItem.init(customView: modeSwitch);
-        self.tabBarController!.navigationItem.setRightBarButtonItem(navigationBarRightButtonItem, animated: false)
+        self.tabBarController!.navigationItem.setRightBarButton(navigationBarRightButtonItem, animated: false)
         
         wotdGlossLabel.text = wordOfTheDay.gloss
         wotdGlossLabel.sizeToFit()
@@ -350,78 +350,78 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
         self.selectEntry(wordOfTheDay)
 
-        handshapeSelector.selectItemAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), animated: false, scrollPosition: .Left)
-        locationSelector.selectItemAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), animated: false, scrollPosition: .Left)
+        handshapeSelector.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .left)
+        locationSelector.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .left)
         self.selectSearchMode(modeSwitch)
     }
     
     override func viewDidLayoutSubviews() {
         // Autosize the scrollview
-        var contentRect = CGRectZero
+        var contentRect = CGRect.zero
         for view: UIView in self.scrollView.subviews {
-            contentRect = CGRectUnion(contentRect, view.frame)
+            contentRect = contentRect.union(view.frame)
         }
         self.scrollView.contentSize = contentRect.size
         self.scrollView.contentSize.height = contentRect.size.height + 150
     }
 
     // MARK: Callback functions
-    func selectWotd(sender: UITapGestureRecognizer) {
-        if sender.state == .Ended {
+    func selectWotd(_ sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
             self.selectEntry(wordOfTheDay)
             searchBar.resignFirstResponder()
             self.delegate?.didSelectEntry(wordOfTheDay)
         }
     }
 
-    func selectSearchMode(sender: UISegmentedControl) {
+    func selectSearchMode(_ sender: UISegmentedControl) {
         self.tabBarController?.selectedIndex = 0
         switch sender.selectedSegmentIndex {
         case 0:
             searchBar.text = ""
-            searchBar.userInteractionEnabled = true
+            searchBar.isUserInteractionEnabled = true
             searchBar.becomeFirstResponder()
-            scrollView.hidden = false
+            scrollView.isHidden = false
             searchTable.tableHeaderView = nil
             searchTable.reloadData()
         case 1:
             searchBar.text = "(handshape search)"
             searchBar.resignFirstResponder()
-            searchBar.userInteractionEnabled = false
-            scrollView.hidden = true
+            searchBar.isUserInteractionEnabled = false
+            scrollView.isHidden = true
             searchTable.tableHeaderView = searchSelectorView
 
             // The UICollectionViewDelegate protocol requires that we provide an NSIndexPath instance
             // and prevents us from making it optional but the NSIndexPath we provide here is ignored
             // by our implementation
-            self.collectionView(handshapeSelector, didSelectItemAtIndexPath: NSIndexPath(index: 0))
+            self.collectionView(handshapeSelector, didSelectItemAt: IndexPath(index: 0))
         default: break
         }
 
         if searchResults.count > 0 {
-            searchTable.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), atScrollPosition: .Bottom, animated: false)
+            searchTable.scrollToRow(at: IndexPath(row: 0, section: 0), at: .bottom, animated: false)
         }
     }
 
-    func positionForBar(bar: UIBarPositioning) -> UIBarPosition {
-        return .TopAttached
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
     }
 
-    func searchBar(searchBar: UISearchBar, textDidChange searchText: String) {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText.characters.count == 0 {
-            scrollView.hidden = false
+            scrollView.isHidden = false
             return
         }
-        scrollView.hidden = true
-        searchResults = dict.searchFor(searchText)
+        scrollView.isHidden = true
+        searchResults = dict.search(for: searchText) as! [AnyObject]
         searchTable.reloadData()
     }
 
-    func selectEntry(entry: DictEntry) {
-        NSNotificationCenter.defaultCenter().postNotificationName(EntrySelectedName, object: nil, userInfo: ["entry": entry])
+    func selectEntry(_ entry: DictEntry) {
+        NotificationCenter.default.post(name: Notification.Name(rawValue: EntrySelectedName), object: nil, userInfo: ["entry": entry])
     }
 
-    func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }
 
@@ -431,23 +431,23 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
     // MARK: UITableViewDataSource methods
 
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return searchResults.count
     }
 
-    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return "\(searchResults.count) sign\(searchResults.count == 1 ? "" : "s")"
     }
 
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellId = "Cell"
 
-        var cell: UITableViewCell? = tableView.dequeueReusableCellWithIdentifier(cellId)
+        var cell: UITableViewCell? = tableView.dequeueReusableCell(withIdentifier: cellId)
 
         if cell == nil {
-            cell = UITableViewCell(style: .Subtitle, reuseIdentifier: cellId)
-            let iv: UIImageView = UIImageView(frame: CGRectMake(0, 2, tableView.rowHeight * 2, tableView.rowHeight - 4))
-            iv.contentMode = .ScaleAspectFit
+            cell = UITableViewCell(style: .subtitle, reuseIdentifier: cellId)
+            let iv: UIImageView = UIImageView(frame: CGRect(x: 0, y: 2, width: tableView.rowHeight * 2, height: tableView.rowHeight - 4))
+            iv.contentMode = .scaleAspectFit
             cell!.accessoryView = iv
         }
 
@@ -460,7 +460,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         return cell!
     }
 
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let entry: DictEntry = searchResults[indexPath.row] as! DictEntry
         self.selectEntry(entry)
         searchBar.resignFirstResponder()
@@ -470,7 +470,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
 
     // MARK: UICollectionViewDelegate methods
 
-    func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView == handshapeSelector {
             return handShapes.count
         }
@@ -480,33 +480,33 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         return 0
     }
 
-    func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         var cell: UICollectionViewCell
         if indexPath.row == 0 {
-            cell = collectionView.dequeueReusableCellWithReuseIdentifier(HandshapeAnyCellIdentifier, forIndexPath: indexPath)
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: HandshapeAnyCellIdentifier, for: indexPath)
             var label: UILabel! = cell.contentView.viewWithTag(1) as! UILabel!
             if label == nil {
-                label = UILabel(frame: CGRectInset(cell.contentView.bounds, 3, 3))
+                label = UILabel(frame: cell.contentView.bounds.insetBy(dx: 3, dy: 3))
                 label.tag = 1
                 label.text = "(any)"
-                label.textAlignment = .Center
-                label.backgroundColor = UIColor.whiteColor()
+                label.textAlignment = .center
+                label.backgroundColor = UIColor.white
                 cell.contentView.addSubview(label)
                 cell.selectedBackgroundView = UIView(frame: cell.contentView.frame)
-                cell.selectedBackgroundView!.backgroundColor = UIColor.blueColor()
+                cell.selectedBackgroundView!.backgroundColor = UIColor.blue
             }
         }
         else {
-            cell = collectionView.dequeueReusableCellWithReuseIdentifier(HandshapeIconCellIdentifier, forIndexPath: indexPath)
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: HandshapeIconCellIdentifier, for: indexPath)
             
             var img: UIImageView! = cell.contentView.viewWithTag(1) as! UIImageView!
             if img == nil {
-                img = UIImageView(frame: CGRectInset(cell.contentView.bounds, 3, 3))
+                img = UIImageView(frame: cell.contentView.bounds.insetBy(dx: 3, dy: 3))
                 img.tag = 1
-                img.contentMode = .ScaleAspectFit
+                img.contentMode = .scaleAspectFit
                 cell.contentView.addSubview(img)
                 cell.selectedBackgroundView = UIView(frame: cell.contentView.frame)
-                cell.selectedBackgroundView!.backgroundColor = UIColor.blueColor()
+                cell.selectedBackgroundView!.backgroundColor = UIColor.blue
             }
             if collectionView == handshapeSelector {
                 img.image = UIImage(named: "handshape.\(handShapes[indexPath.row]).png")
@@ -515,14 +515,14 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
                 img.image = UIImage(named: Locations[indexPath.row][1])
             }
             
-            img.backgroundColor = UIColor.whiteColor()
+            img.backgroundColor = UIColor.white
         }
         return cell
     }
 
-    func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath _indexPath: NSIndexPath) {
-        guard let handshapeIndexPath: [NSIndexPath] = handshapeSelector.indexPathsForSelectedItems() else { return }
-        guard let locationIndexPath: [NSIndexPath] = locationSelector.indexPathsForSelectedItems() else { return }
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt _indexPath: IndexPath) {
+        guard let handshapeIndexPath: [IndexPath] = handshapeSelector.indexPathsForSelectedItems else { return }
+        guard let locationIndexPath: [IndexPath] = locationSelector.indexPathsForSelectedItems else { return }
 
         // empty arrays => no selected items
         if handshapeIndexPath.isEmpty || locationIndexPath.isEmpty { return }
@@ -541,19 +541,19 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         }
 
         // searchHandshape(targetHandshape: String?, location: String?) -> [AnyObject]
-        searchResults = dict.searchHandshape(targetHandshape, location: location)
+        searchResults = dict.searchHandshape(targetHandshape, location: location) as! [AnyObject]
         searchTable.reloadData()
     }
     
     
-    func webViewDidStartLoad(webView: UIWebView) {
+    func webViewDidStartLoad(_ webView: UIWebView) {
         var frame = webView.frame
         frame.size.height = 5.0
         webView.frame = frame
     }
     
-    func webViewDidFinishLoad(webView: UIWebView) {
-        let mWebViewTextSize = webView.sizeThatFits(CGSizeMake(1.0, 1.0))
+    func webViewDidFinishLoad(_ webView: UIWebView) {
+        let mWebViewTextSize = webView.sizeThatFits(CGSize(width: 1.0, height: 1.0))
         // Pass about any size
         var mWebViewFrame = webView.frame
         mWebViewFrame.size.height = mWebViewTextSize.height
@@ -562,22 +562,22 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
         webView.scrollView.bounces = false
     }
     
-    func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
-        if request.URL!.fileURL {
+    func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        if request.url!.isFileURL {
             return true
         }
         
-        if request.URL!.scheme == "follow" {
+        if request.url!.scheme == "follow" {
             openTwitterClientForUserName("NZSLDict")
             return false
         }
         
-        UIApplication.sharedApplication().openURL(request.URL!)
+        UIApplication.shared.openURL(request.url!)
         return false
     }
     
     // https://gist.github.com/vhbit/958738
-    func openTwitterClientForUserName(userName: String) -> Bool {
+    func openTwitterClientForUserName(_ userName: String) -> Bool {
         let urls = [
             "twitter:@{username}", // Twitter
             "tweetbot:///user_profile/{username}", // TweetBot
@@ -593,11 +593,11 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
             "http://twitter.com/{username}", // Web fallback,
         ]
         
-        let application: UIApplication = UIApplication.sharedApplication()
+        let application: UIApplication = UIApplication.shared
         
         for candidate in urls {
-            let urlString = candidate.stringByReplacingOccurrencesOfString("{username}", withString:userName)
-            if let url = NSURL(string: urlString) {
+            let urlString = candidate.replacingOccurrences(of: "{username}", with:userName)
+            if let url = URL(string: urlString) {
                 print("testing \(url)")
                 if application.canOpenURL(url) {
                     print("we can open \(url)")

--- a/NZSLDict/Classes/SearchViewControllerDelegate.swift
+++ b/NZSLDict/Classes/SearchViewControllerDelegate.swift
@@ -1,3 +1,3 @@
 @objc protocol SearchViewControllerDelegate {
-    func didSelectEntry(entry: DictEntry)
+    func didSelectEntry(_ entry: DictEntry)
 }

--- a/NZSLDict/Classes/ViewControllerPad.swift
+++ b/NZSLDict/Classes/ViewControllerPad.swift
@@ -10,7 +10,7 @@ class ViewControllerPad: UISplitViewController {
     // var diagramController: UIViewController!
     // var videoController: UIViewController!
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
         searchController = SearchViewController()
@@ -28,7 +28,7 @@ class ViewControllerPad: UISplitViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func shouldAutorotate() -> Bool {
+    override var shouldAutorotate : Bool {
         return true
     }
 }

--- a/NZSLDict/Classes/ViewControllerPhone.swift
+++ b/NZSLDict/Classes/ViewControllerPhone.swift
@@ -6,7 +6,7 @@ class ViewControllerPhone: UITabBarController, ViewControllerDelegate, SearchVie
     var videoController: VideoViewController!
     var historyController: HistoryViewController!
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
@@ -16,7 +16,7 @@ class ViewControllerPhone: UITabBarController, ViewControllerDelegate, SearchVie
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.tabBar.backgroundColor = UIColor.whiteColor()
+        self.tabBar.backgroundColor = UIColor.white
 
         searchController = SearchViewController()
         diagramController = DiagramViewController()
@@ -36,11 +36,11 @@ class ViewControllerPhone: UITabBarController, ViewControllerDelegate, SearchVie
         historyController.delegate = self
     }
 
-       override func shouldAutorotate() -> Bool {
+       override var shouldAutorotate : Bool {
         return true
     }
 
-    func didSelectEntry(entry: DictEntry) {
+    func didSelectEntry(_ entry: DictEntry) {
         self.selectedViewController = diagramController
     }
 

--- a/SignsDictionaryTest.swift
+++ b/SignsDictionaryTest.swift
@@ -24,39 +24,39 @@ class SignsDictionaryTest: XCTestCase {
     }
     
     func test_searchForExactMainGlossMatch() {
-        var results = signsDictionary.searchFor("Book");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "Book");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "book");
     }
     
     func test_searchForExactMaoriGlossMatch() {
-        var results = signsDictionary.searchFor("ora");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "ora");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "alive, live, survive");
     }
     
     func test_searchForContainsMainGloss() {
-        var results = signsDictionary.searchFor("classif");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "classif");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "classifier");
     }
     
     func test_searchForContainsMaoriGloss() {
-        var results = signsDictionary.searchFor("akorang");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "akorang");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "course");
     }
     
     func test_searchForExactSecondaryGloss() {
-        var results = signsDictionary.searchFor("nought");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "nought");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "zero");
     }
     
     
     func test_searchForContainsSecondaryGloss() {
-        var results = signsDictionary.searchFor("not get involved, nothing to do with");
-        let firstResult: DictEntry = results[0] as! DictEntry;
+        var results = signsDictionary.search(for: "not get involved, nothing to do with");
+        let firstResult: DictEntry = results![0] as! DictEntry;
         assert(firstResult.gloss == "neutral");
     }
     
@@ -64,29 +64,29 @@ class SignsDictionaryTest: XCTestCase {
         // There are 3 unique results for Auckland. This search term is used
         // because it was known to break and show duplicates, but also includes 
         // more than 1 unique result for the term
-        let results = signsDictionary.searchFor("Auckland");
-        let resultsMatchingAuckland = results.filter { $0.gloss == "Auckland" }
-        assert(resultsMatchingAuckland.count == 3)
+        let results = signsDictionary.search(for: "Auckland");
+        let resultsMatchingAuckland = results?.filter { ($0 as AnyObject).gloss == "Auckland" }
+        assert(resultsMatchingAuckland?.count == 3)
     }
     
     func test_searchForStartsWithMainGloss() {
-        let results = signsDictionary.searchFor("bus");
-        let firstResult = results[0] as! DictEntry;
+        let results = signsDictionary.search(for: "bus");
+        let firstResult = results?[0] as! DictEntry;
         assert(firstResult.gloss == "bus stop");
     }
     
     func test_searchForStartsWithMaoriGloss() {
-        let results = signsDictionary.searchFor("Aorang");
-        let firstResult = results[0] as! DictEntry;
+        let results = signsDictionary.search(for: "Aorang");
+        let firstResult = results?[0] as! DictEntry;
         assert(firstResult.gloss == "Feilding");
     }
     
     func test_searchForPrioritisesResults() {
         // A nice general term that returns a range of matched signs
-        let results = signsDictionary.searchFor("bus");
-        let result1 = results[0] as! DictEntry;
-        let result2 = results[1] as! DictEntry;
-        let result3 = results[2] as! DictEntry;
+        let results = signsDictionary.search(for: "bus");
+        let result1 = results?[0] as! DictEntry;
+        let result2 = results?[1] as! DictEntry;
+        let result3 = results?[2] as! DictEntry;
         
         assert(result1.gloss == "bus stop");
         assert(result2.gloss == "bus, truck");


### PR DESCRIPTION
I had to make this conversion in the end, as I have upgraded my version of Xcode, and it will no longer run the project on Swift 2.3 (since Xcode 8.3). Additionally, when I tried to roll back to Xcode 7, I had different toolchain problems.

Overall, I decided it was going to be easier to just upgrade. This pull request is a result of allowing Xcode to automatically update the Swift code to Swift 3.0, and performing a series of tests to check that the app starts and basically functions.